### PR TITLE
Bumped stylelint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "ember test"
   },
   "dependencies": {
-    "stylelint": "^8.3.1"
+    "stylelint": "^14.16.1"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Was running into problems using some stylelint plugins as the version included here was missing newer rules.

In my case specifically 'alpha-value-notation'